### PR TITLE
Bug/fix extra quote

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "odata-v4-server-tls-support",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "description": "OData V4 Server",
   "main": "build/lib/index.js",
   "typings": "build/lib/index",

--- a/src/lib/processor.ts
+++ b/src/lib/processor.ts
@@ -619,7 +619,7 @@ export class ODataProcessor extends Transform {
                         this.push('{"value":[]}');
                     } else {
                         let md = `{"@odata.context":"${this.odataContext}"`;
-                        if (this.streamNextLink) { md = `${md},{"@odata.nextLink":"${this.streamNextLink}"`; }
+                        if (this.streamNextLink) { md = `${md},"@odata.nextLink":"${this.streamNextLink}"`; }
                         this.push(`${md},"value":[]}`);
                     }
                 }
@@ -629,7 +629,7 @@ export class ODataProcessor extends Transform {
                 this.push('{"value":[]}');
             } else {
                 let md = `{"@odata.context":"${this.odataContext}"`;
-                if (this.streamNextLink) { md = `${md},{"@odata.nextLink":"${this.streamNextLink}"`; }
+                if (this.streamNextLink) { md = `${md},"@odata.nextLink":"${this.streamNextLink}"`; }
                 this.push(`${md},"value":[]}`);
             }
         }

--- a/src/lib/processor.ts
+++ b/src/lib/processor.ts
@@ -620,7 +620,7 @@ export class ODataProcessor extends Transform {
                     } else {
                         let md = `{"@odata.context":"${this.odataContext}"`;
                         if (this.streamNextLink) { md = `${md},{"@odata.nextLink":"${this.streamNextLink}"`; }
-                        this.push(`${md}","value":[]}`);
+                        this.push(`${md},"value":[]}`);
                     }
                 }
             }
@@ -630,7 +630,7 @@ export class ODataProcessor extends Transform {
             } else {
                 let md = `{"@odata.context":"${this.odataContext}"`;
                 if (this.streamNextLink) { md = `${md},{"@odata.nextLink":"${this.streamNextLink}"`; }
-                this.push(`${md}","value":[]}`);
+                this.push(`${md},"value":[]}`);
             }
         }
         this.streamEnd = true;

--- a/src/test/execute.spec.ts
+++ b/src/test/execute.spec.ts
@@ -444,7 +444,7 @@ describe("OData execute", () => {
             return TestServer.execute("/NonExistent", "GET")
                 .then((result) => { })
                 .catch(err => {
-                    expect(err.message).to.equal("Cannot read property 'node' of undefined");
+                    expect(err.message).to.equal("Cannot read properties of undefined (reading 'node')");
                 });
         });
     });

--- a/src/test/http.spec.ts
+++ b/src/test/http.spec.ts
@@ -817,10 +817,10 @@ describe("OData HTTP", () => {
     describe("Non existent entity", () => {
         it("should return cannot read property node error", () => {
             return request.get(`http://localhost:3002/NonExistent`, (err, req, res) => {
-                expect(JSON.parse(res).error.message).to.equal("Cannot read property 'node' of undefined");
+                expect(JSON.parse(res).error.message).to.equal("Cannot read properties of undefined (reading 'node')");
             })
                 .catch(ex => {
-                    expect(JSON.parse(ex.error).error.message).to.equal("Cannot read property 'node' of undefined");
+                    expect(JSON.parse(ex.error).error.message).to.equal("Cannot read properties of undefined (reading 'node')");
                 });
         });
     });

--- a/src/test/stream.spec.ts
+++ b/src/test/stream.spec.ts
@@ -634,7 +634,7 @@ if (typeof describe == "function") {
                     expect(result).to.deep.equal({ statusCode: 204 });
                 })
                 .catch((error) => {
-                    expect(error.message).to.equal("Cannot read property 'node' of undefined");
+                    expect(error.message).to.equal("Cannot read properties of undefined (reading 'node')");
                 })
             })
         });


### PR DESCRIPTION
Description:

This PR fixes too many quotation marks in the response.
Our clients reported that in Odata interface they get too many quotation marks in the response (after Conversations), resulting in an invalid json.
```
If a period is specified via the odata interface using $filter for which no data exists, there is one too many quotation marks in the response (after Conversations), resulting in an invalid json: 

https://odata-arag-v4.cognigy.cloud/Conversations/?$filter=timestamp gt 2021-01-11T00:00:00.000Z and timestamp lt 2021-01-18T00:00:00.000Z&apikey=20....

{
"@odata.context": "https://odata-arag-v4.cognigy.cloud/$metadata#Conversations"","value":[]}
```
We ran the investigation ant found out that, this bug has to be fixed in this package.

Success criteria:

- service-analytics-odata still works fine after updating dependencies. 

How to test (steps):

1. After this Pr is merged, we need to update the service-analytics-odata  dependency and check if the problem is solved.

Additional considerations (describe):

- [ ] This PR impacts NLU
- [ ] This PR might have performance implications
- [ ] This PR changes an existing data model (and might affect existing legacy data)
  - Examples: adding, renaming, removing a field or changing the format or constraints of a field

Security implications (describe):

- [ ] Possible injection vector
- [ ] Authentication/Access controls touched
- [ ] Sensitive Data could be exposed
- [ ] XSS
- [ ] Logging/Monitoring touched
- [ ] Exchanges data with external systems
- [ ] No security implications

feature/0000-service-analytics-odata-security-updates