### PR TITLE
feat: add npm trusted publishing with OIDC authentication

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,57 @@
+# =============================================================================
+# @cognigy/odata-v4-server-tls-support - Publish to npm
+# =============================================================================
+# Triggered on push to main branch.
+# Builds the package and publishes to npm using trusted publishing (OIDC).
+# =============================================================================
+
+name: Publish to npm
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  id-token: write # Required for npm trusted publishing (OIDC)
+  contents: read
+
+jobs:
+  publish:
+    name: Build and Publish
+    runs-on: ubuntu-latest
+
+    steps:
+      # ----------------------------------------------------------------------
+      # Checkout the repository
+      # ----------------------------------------------------------------------
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # ----------------------------------------------------------------------
+      # Setup Node.js with npm registry (Node 24 includes npm 11.5.1+)
+      # ----------------------------------------------------------------------
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+
+      # ----------------------------------------------------------------------
+      # Install dependencies
+      # ----------------------------------------------------------------------
+      - name: Install dependencies
+        run: npm ci --legacy-peer-deps
+
+      # ----------------------------------------------------------------------
+      # Build the package
+      # ----------------------------------------------------------------------
+      - name: Build
+        run: npm run build
+
+      # ----------------------------------------------------------------------
+      # Publish to npm using OIDC (no token needed)
+      # ----------------------------------------------------------------------
+      - name: Publish to npm
+        run: npm publish --access public

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,7 @@
 # =============================================================================
 # @cognigy/odata-v4-server-tls-support - Publish to npm
 # =============================================================================
-# Triggered on push to main branch.
+# Triggered when a version tag (v*) is pushed.
 # Builds the package and publishes to npm using trusted publishing (OIDC).
 # =============================================================================
 
@@ -9,8 +9,8 @@ name: Publish to npm
 
 on:
   push:
-    branches:
-      - main
+    tags:
+      - 'v*'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow for npm publishing using trusted publishing (OIDC)
- Eliminates the need for long-lived npm tokens
- Automatically generates provenance attestations for published packages
- Triggers on push to main branch

## Test plan
1. Configure trusted publisher on npmjs.com for this package:
   - Organization: `Cognigy`
   - Repository: `odata-v4-server`
   - Workflow filename: `publish.yml`
2. Merge this PR and push to main
3. Verify the package is published successfully without npm tokens